### PR TITLE
Ability to partition Cosmos DB collection by EntityType

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ CosmosDb Job Store for Quartz.NET
 
 We have created this project to allow clustered Quartz.NET store jobs into CosmosDb. It is more or less port of [Quartz.NET MongoDb Job Store](https://github.com/chrisdrobison/mongodb-quartz-net).   
 
-## Basic Usage##
+## Basic Usage
 
 ```cs
 var properties = new NameValueCollection();
@@ -19,6 +19,11 @@ properties[$"{StdSchedulerFactory.PropertyJobStorePrefix}.Clustered"] = "true";
 
 var scheduler = new StdSchedulerFactory(properties);
 return scheduler.GetScheduler();
+```
+### Collection partition key
+By default Cosmos DB collection partitioned by `PropertySchedulerInstanceName`, instead entity type (e.g. 'Trigger', 'JobDetails') can be used as the partition key.
+```cs
+properties[$"{StdSchedulerFactory.PropertyJobStorePrefix}.{nameof(CosmosDbJobStore.PartitionPerEntityType)}"] = "true";
 ```
 
 ## Nuget ##

--- a/src/Quartz.Spi.CosmosDbJobStore/CosmosDbJobStore.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/CosmosDbJobStore.cs
@@ -141,6 +141,11 @@ namespace Quartz.Spi.CosmosDbJobStore
         /// </summary>
         public int MaxMisfiresToHandleAtATime { get; set; }
 
+        /// <summary>
+        /// If true, uses the entity type as the partition key; otherwise, uses instanceName.
+        /// </summary>
+        public bool PartitionPerEntityType { get; set; }
+
         protected DateTimeOffset MisfireTime
         {
             get
@@ -185,14 +190,14 @@ namespace Quartz.Spi.CosmosDbJobStore
                     MaxRetryAttemptsOnThrottledRequests = 10
                 }
             }); // TODO Configurable
-            
-            _lockManager = new LockManager(new LockRepository(documentClient, DatabaseId, CollectionId, InstanceName), InstanceName, InstanceId, LockTtlSeconds);
-            _calendarRepository = new CalendarRepository(documentClient, DatabaseId, CollectionId, InstanceName);
-            _triggerRepository = new TriggerRepository(documentClient, DatabaseId, CollectionId, InstanceName);
-            _jobRepository = new JobRepository(documentClient, DatabaseId, CollectionId, InstanceName);
-            _schedulerRepository = new SchedulerRepository(documentClient, DatabaseId, CollectionId, InstanceName);
-            _firedTriggerRepository = new FiredTriggerRepository(documentClient, DatabaseId, CollectionId, InstanceName);
-            _pausedTriggerGroupRepository = new PausedTriggerGroupRepository(documentClient, DatabaseId, CollectionId, InstanceName);
+
+            _lockManager = new LockManager(new LockRepository(documentClient, DatabaseId, CollectionId, InstanceName, PartitionPerEntityType), InstanceName, InstanceId, LockTtlSeconds);
+            _calendarRepository = new CalendarRepository(documentClient, DatabaseId, CollectionId, InstanceName, PartitionPerEntityType);
+            _triggerRepository = new TriggerRepository(documentClient, DatabaseId, CollectionId, InstanceName, PartitionPerEntityType);
+            _jobRepository = new JobRepository(documentClient, DatabaseId, CollectionId, InstanceName, PartitionPerEntityType);
+            _schedulerRepository = new SchedulerRepository(documentClient, DatabaseId, CollectionId, InstanceName, PartitionPerEntityType);
+            _firedTriggerRepository = new FiredTriggerRepository(documentClient, DatabaseId, CollectionId, InstanceName, PartitionPerEntityType);
+            _pausedTriggerGroupRepository = new PausedTriggerGroupRepository(documentClient, DatabaseId, CollectionId, InstanceName, PartitionPerEntityType);
             await _schedulerRepository.EnsureInitialized(); // All repositories uses one collection
         }
         

--- a/src/Quartz.Spi.CosmosDbJobStore/Quartz.Spi.CosmosDbJobStore.csproj
+++ b/src/Quartz.Spi.CosmosDbJobStore/Quartz.Spi.CosmosDbJobStore.csproj
@@ -6,7 +6,7 @@
         <RootNamespace>Quartz.Spi.CosmosDbJobStore</RootNamespace>
         <LangVersion>latest</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.6.0</Version>
+        <Version>0.7.0</Version>
         <Authors>Frantisek Jandos</Authors>
         <Company>Oriflame Software</Company>
         <PackageLicenseUrl>https://github.com/Oriflame/cosmosdb-quartznet/blob/master/LICENSE.txt</PackageLicenseUrl>

--- a/src/Quartz.Spi.CosmosDbJobStore/Repositories/CalendarRepository.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/Repositories/CalendarRepository.cs
@@ -8,8 +8,8 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
 {
     internal class CalendarRepository : CosmosDbRepositoryBase<PersistentCalendar>
     {
-        public CalendarRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName)
-            : base(documentClient, databaseId, collectionId, PersistentCalendar.EntityType, instanceName)
+        public CalendarRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName, bool partitionPerEntityType)
+            : base(documentClient, databaseId, collectionId, PersistentCalendar.EntityType, instanceName, partitionPerEntityType)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         public Task<IReadOnlyCollection<string>> GetCalendarNames()
         {
             return Task.FromResult((IReadOnlyCollection<string>)_documentClient
-                .CreateDocumentQuery<PersistentCalendar>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentCalendar>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName)
                 .Select(x => x.CalendarName)
                 .AsEnumerable()

--- a/src/Quartz.Spi.CosmosDbJobStore/Repositories/FiredTriggerRepository.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/Repositories/FiredTriggerRepository.cs
@@ -8,8 +8,8 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
 {
     internal class FiredTriggerRepository : CosmosDbRepositoryBase<PersistentFiredTrigger>
     {
-        public FiredTriggerRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName)
-            : base(documentClient, databaseId, collectionId, PersistentFiredTrigger.EntityType, instanceName)
+        public FiredTriggerRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName, bool partitionPerEntityType)
+            : base(documentClient, databaseId, collectionId, PersistentFiredTrigger.EntityType, instanceName, partitionPerEntityType)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         public Task<IList<PersistentFiredTrigger>> GetAllByJob(string jobName, string jobGroup)
         {
             return Task.FromResult<IList<PersistentFiredTrigger>>(_documentClient
-                .CreateDocumentQuery<PersistentFiredTrigger>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentFiredTrigger>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.JobGroup == jobGroup && x.JobName == jobName)
                 .AsEnumerable()
                 .ToList());
@@ -26,7 +26,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         public Task<IList<PersistentFiredTrigger>> GetAllRecoverableByInstanceId(string instanceId)
         {
             return Task.FromResult<IList<PersistentFiredTrigger>>(_documentClient
-                .CreateDocumentQuery<PersistentFiredTrigger>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentFiredTrigger>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.InstanceId == instanceId && x.RequestsRecovery)
                 .AsEnumerable()
                 .ToList());
@@ -35,7 +35,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         public Task<IList<PersistentFiredTrigger>> GetAllByInstanceId(string instanceId)
         {
             return Task.FromResult<IList<PersistentFiredTrigger>>(_documentClient
-                .CreateDocumentQuery<PersistentFiredTrigger>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentFiredTrigger>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.InstanceId == instanceId)
                 .AsEnumerable()
                 .ToList());
@@ -51,7 +51,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
             // We may introduce paging if performance boost is necessary
             
             var triggers = _documentClient
-                .CreateDocumentQuery<PersistentFiredTrigger>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentFiredTrigger>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.InstanceId == instanceId)
                 .Select(x => x.Id)
                 .AsEnumerable()
@@ -59,7 +59,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
 
             foreach (var trigger in triggers)
             {
-                await _documentClient.DeleteDocumentAsync(CreateDocumentUri(trigger), CreateRequestOptions());
+                await _documentClient.DeleteDocumentAsync(CreateDocumentUri(trigger), RequestOptions);
             }
             
             return triggers.Count;
@@ -68,7 +68,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         public Task<IList<PersistentFiredTrigger>> GetAllByTrigger(string triggerKeyName, string triggerKeyGroup)
         {
             return Task.FromResult<IList<PersistentFiredTrigger>>(_documentClient
-                .CreateDocumentQuery<PersistentFiredTrigger>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentFiredTrigger>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.TriggerGroup == triggerKeyGroup && (x.TriggerName == null || x.TriggerName == triggerKeyName))
                 .AsEnumerable()
                 .ToList());

--- a/src/Quartz.Spi.CosmosDbJobStore/Repositories/JobRepository.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/Repositories/JobRepository.cs
@@ -9,8 +9,8 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
     internal class JobRepository : CosmosDbRepositoryBase<PersistentJob>
     {
         public JobRepository(IDocumentClient documentClient, string databaseId, string collectionId,
-            string instanceName)
-            : base(documentClient, databaseId, collectionId, PersistentJob.EntityType, instanceName)
+            string instanceName, bool partitionPerEntityType)
+            : base(documentClient, databaseId, collectionId, PersistentJob.EntityType, instanceName, partitionPerEntityType)
         {
         }
 
@@ -18,7 +18,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         public Task<IReadOnlyCollection<string>> GetGroups()
         {
             return Task.FromResult<IReadOnlyCollection<string>>(_documentClient
-                .CreateDocumentQuery<PersistentJob>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentJob>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName)
                 .Select(x => x.Group)
                 .AsEnumerable()

--- a/src/Quartz.Spi.CosmosDbJobStore/Repositories/LockRepository.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/Repositories/LockRepository.cs
@@ -9,8 +9,8 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
 {
     public class LockRepository : CosmosDbRepositoryBase<PersistentLock>
     {
-        public LockRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName) 
-            : base(documentClient, databaseId, collectionId, PersistentLock.EntityType, instanceName)
+        public LockRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName, bool partitionPerEntityType)
+            : base(documentClient, databaseId, collectionId, PersistentLock.EntityType, instanceName, partitionPerEntityType)
         {
         }
 
@@ -18,7 +18,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         {
             try
             {
-                await _documentClient.CreateDocumentAsync(_collectionUri, lck, CreateRequestOptions(), true);
+                await _documentClient.CreateDocumentAsync(_collectionUri, lck, RequestOptions, true);
                 return true;
             }
             catch (DocumentClientException e) when (e.StatusCode == HttpStatusCode.Conflict)
@@ -31,7 +31,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         {
             try
             {
-                await _documentClient.DeleteDocumentAsync(CreateDocumentUri(lockId), CreateRequestOptions());
+                await _documentClient.DeleteDocumentAsync(CreateDocumentUri(lockId), RequestOptions);
                 return true;
             }
             catch (DocumentClientException e) when (e.StatusCode == HttpStatusCode.NotFound)
@@ -43,7 +43,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         public Task<IList<PersistentLock>> GetAllByInstanceId(string instanceId)
         {
             return Task.FromResult<IList<PersistentLock>>(_documentClient
-                .CreateDocumentQuery<PersistentLock>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentLock>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.InstanceId == instanceId)
                 .AsEnumerable()
                 .ToList());

--- a/src/Quartz.Spi.CosmosDbJobStore/Repositories/PausedTriggerGroupRepository.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/Repositories/PausedTriggerGroupRepository.cs
@@ -8,15 +8,15 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
 {
     internal class PausedTriggerGroupRepository : CosmosDbRepositoryBase<PausedTriggerGroup>
     {
-        public PausedTriggerGroupRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName)
-            : base(documentClient, databaseId, collectionId, PausedTriggerGroup.EntityType, instanceName)
+        public PausedTriggerGroupRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName, bool partitionPerEntityType)
+            : base(documentClient, databaseId, collectionId, PausedTriggerGroup.EntityType, instanceName, partitionPerEntityType)
         {
         }
 
         
         public Task<IReadOnlyCollection<string>> GetGroups()
         {
-            return Task.FromResult<IReadOnlyCollection<string>>(_documentClient.CreateDocumentQuery<PausedTriggerGroup>(_collectionUri, CreateFeedOptions())
+            return Task.FromResult<IReadOnlyCollection<string>>(_documentClient.CreateDocumentQuery<PausedTriggerGroup>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName)
                 .Select(x => x.Group)
                 .AsEnumerable()

--- a/src/Quartz.Spi.CosmosDbJobStore/Repositories/SchedulerRepository.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/Repositories/SchedulerRepository.cs
@@ -5,8 +5,8 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
 {
     internal class SchedulerRepository : CosmosDbRepositoryBase<PersistentScheduler>
     {
-        public SchedulerRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName)
-            : base(documentClient, databaseId, collectionId, PersistentScheduler.EntityType, instanceName)
+        public SchedulerRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName, bool partitionPerEntityType)
+            : base(documentClient, databaseId, collectionId, PersistentScheduler.EntityType, instanceName, partitionPerEntityType)
         {
         }
     }

--- a/src/Quartz.Spi.CosmosDbJobStore/Repositories/TriggerRepository.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/Repositories/TriggerRepository.cs
@@ -9,8 +9,8 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
 {
     internal class TriggerRepository : CosmosDbRepositoryBase<PersistentTriggerBase>
     {
-        public TriggerRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName)
-            : base(documentClient, databaseId, collectionId, PersistentTriggerBase.EntityType, instanceName)
+        public TriggerRepository(IDocumentClient documentClient, string databaseId, string collectionId, string instanceName, bool partitionPerEntityType)
+            : base(documentClient, databaseId, collectionId, PersistentTriggerBase.EntityType, instanceName, partitionPerEntityType)
         {
         }
 
@@ -18,7 +18,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         public Task<IList<PersistentTriggerBase>> GetAllByJob(string jobName, string jobGroup)
         {
             return Task.FromResult<IList<PersistentTriggerBase>>(_documentClient
-                .CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.JobGroup == jobGroup && x.JobName == jobName)
                 .AsEnumerable()
                 .ToList());
@@ -30,7 +30,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
             var jobGroup = jobKey?.Group;
             
             return Task.FromResult<IList<PersistentTriggerBase>>(_documentClient
-                .CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.JobGroup == jobGroup && x.JobName == jobName && x.State == state)
                 .AsEnumerable()
                 .ToList());
@@ -39,14 +39,14 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         public Task<int> CountByJob(string jobName, string jobGroup)
         {
             return Task.FromResult(_documentClient
-                .CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, FeedOptions)
                 .Count(x => x.Type == _type && x.InstanceName == _instanceName && x.JobGroup == jobGroup && x.JobName == jobName));
         }
         
         public Task<IList<PersistentTriggerBase>> GetAllCompleteByCalendar(string calendarName)
         {
             return Task.FromResult<IList<PersistentTriggerBase>>(_documentClient
-                .CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.CalendarName == calendarName)
                 .AsEnumerable()
                 .ToList());
@@ -55,7 +55,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         public Task<bool> ExistsByCalendar(string calendarName)
         {
             return Task.FromResult(_documentClient
-                .CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, CreateFeedOptions())
+                .CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.CalendarName == calendarName)
                 .Take(1)
                 .AsEnumerable()
@@ -64,7 +64,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         
         public Task<int> GetMisfireCount(DateTimeOffset nextFireTime)
         {
-            return Task.FromResult(_documentClient.CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, CreateFeedOptions())
+            return Task.FromResult(_documentClient.CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, FeedOptions)
                 .Count(x => x.Type == _type && x.InstanceName == _instanceName && x.MisfireInstruction != MisfireInstruction.IgnoreMisfirePolicy && x.NextFireTime < nextFireTime && x.State == PersistentTriggerState.Waiting));
         }
         
@@ -77,7 +77,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         /// <returns></returns>
         public Task<IList<PersistentTriggerBase>> GetAllMisfired(DateTimeOffset nextFireTime, int limit)
         {
-            return Task.FromResult<IList<PersistentTriggerBase>>(_documentClient.CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, CreateFeedOptions())
+            return Task.FromResult<IList<PersistentTriggerBase>>(_documentClient.CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && x.MisfireInstruction != MisfireInstruction.IgnoreMisfirePolicy && x.NextFireTime < nextFireTime && x.State == PersistentTriggerState.Waiting)
                 .OrderBy(x => x.NextFireTime) // Note that Cosmos can't do it at the moment :-( .ThenByDescending(x => x.Priority)
                 .Take(limit)
@@ -87,7 +87,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
         
         public Task<List<PersistentTriggerBase>> GetAllByState(params PersistentTriggerState[] states)
         {
-            return Task.FromResult<List<PersistentTriggerBase>>(_documentClient.CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, CreateFeedOptions())
+            return Task.FromResult<List<PersistentTriggerBase>>(_documentClient.CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName && states.Contains(x.State))
                 .AsEnumerable()
                 .ToList());
@@ -100,14 +100,14 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
             foreach (var trigger in triggers)
             {
                 trigger.State = newState;
-                await _documentClient.UpsertDocumentAsync(CreateDocumentUri(trigger.Id), trigger, CreateRequestOptions(), true);
+                await _documentClient.UpsertDocumentAsync(CreateDocumentUri(trigger.Id), trigger, RequestOptions, true);
             }
             return triggers.Count;
         }
 
         public Task<IReadOnlyCollection<string>> GetGroups()
         {
-            return Task.FromResult<IReadOnlyCollection<string>>(_documentClient.CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, CreateFeedOptions())
+            return Task.FromResult<IReadOnlyCollection<string>>(_documentClient.CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName)
                 .Select(x => x.Group)
                 .AsEnumerable()
@@ -122,7 +122,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Repositories
                 maxCount = 1;
             }
 
-            return Task.FromResult<List<PersistentTriggerBase>>(_documentClient.CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, CreateFeedOptions())
+            return Task.FromResult<List<PersistentTriggerBase>>(_documentClient.CreateDocumentQuery<PersistentTriggerBase>(_collectionUri, FeedOptions)
                 .Where(x => x.Type == _type && x.InstanceName == _instanceName 
                                             && x.State == PersistentTriggerState.Waiting && x.NextFireTime <= noLaterThan 
                                             && (x.MisfireInstruction == -1 || (x.MisfireInstruction != -1 && x.NextFireTime >= noEarlierThan)))


### PR DESCRIPTION
Cosmos DB collection will be partitioned by enity type if the following property is set to true
`properties[$"{StdSchedulerFactory.PropertyJobStorePrefix}.{nameof(CosmosDbJobStore.PartitionPerEntityType)}"] = "true";`

Default behaviour should not be affected by the change.