### PR TITLE
Only store type name and assembly name for fields with type "Type"

### DIFF
--- a/src/Quartz.Spi.CosmosDbJobStore/Quartz.Spi.CosmosDbJobStore.csproj
+++ b/src/Quartz.Spi.CosmosDbJobStore/Quartz.Spi.CosmosDbJobStore.csproj
@@ -6,7 +6,7 @@
         <RootNamespace>Quartz.Spi.CosmosDbJobStore</RootNamespace>
         <LangVersion>latest</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.7.0</Version>
+        <Version>0.7.1</Version>
         <Authors>Frantisek Jandos</Authors>
         <Company>Oriflame Software</Company>
         <PackageLicenseUrl>https://github.com/Oriflame/cosmosdb-quartznet/blob/master/LICENSE.txt</PackageLicenseUrl>

--- a/src/Quartz.Spi.CosmosDbJobStore/Util/InheritedJsonObjectSerializer.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/Util/InheritedJsonObjectSerializer.cs
@@ -17,6 +17,7 @@ namespace Quartz.Spi.CosmosDbJobStore.Util
             var settings = base.CreateSerializerSettings();
             
             settings.Converters.Add(new TimeOfDayConverter());
+            settings.Converters.Add(new TypeConverter());
             settings.TypeNameHandling = TypeNameHandling.All;
             settings.DateFormatHandling = DateFormatHandling.IsoDateFormat;
             settings.DateParseHandling = DateParseHandling.DateTimeOffset;
@@ -63,6 +64,22 @@ namespace Quartz.Spi.CosmosDbJobStore.Util
             {
                 return typeof(TimeOfDay) == objectType;
             }
+        }
+
+        public class TypeConverter : JsonConverter
+        {
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                Type typeValue = (Type) value;
+                writer.WriteValue(typeValue.FullName + ", " + typeValue.Assembly.GetName().Name);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) =>
+                throw new NotImplementedException();
+
+            public override bool CanRead => false;
+
+            public override bool CanConvert(Type objectType) => typeof(Type).IsAssignableFrom(objectType);
         }
     }
 }


### PR DESCRIPTION
We don't want to store full information about the job assembly so that we could update it and still keep jobs running. Currently, we'd have to recreate all jobs if the assembly version changes.

Before
```
{
    "$type": "Quartz.Spi.CosmosDbJobStore.Entities.PersistentJob, Quartz.Spi.CosmosDbJobStore",
    ...
    "JobType": "Companyname.Scheduling.Jobs.HelloJob, Companyname.Scheduling.Jobs, Version=1.0.0.0, Culture=neutral,
    ...
}
```
After
```
{
    "$type": "Quartz.Spi.CosmosDbJobStore.Entities.PersistentJob, Quartz.Spi.CosmosDbJobStore",
    ...
    "JobType": "Companyname.Scheduling.Jobs.HelloJob, Companyname.Scheduling.Jobs",
    ...
}
```