### PR TITLE
Reset trigger from error state

### DIFF
--- a/src/Quartz.Spi.CosmosDbJobStore/CosmosDbJobStore.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/CosmosDbJobStore.cs
@@ -791,6 +791,34 @@ namespace Quartz.Spi.CosmosDbJobStore
             }
         }
 
+        public async Task ResetTriggerFromErrorState(TriggerKey triggerKey, CancellationToken cancellationToken = new CancellationToken())
+        {
+            try
+            {
+                using (await _lockManager.AcquireLock(LockType.TriggerAccess))
+                {
+                    await ResetTriggerFromErrorStateInternal(triggerKey.Name, triggerKey.Group);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new JobPersistenceException(ex.Message, ex);
+            }
+        }
+
+        private async Task ResetTriggerFromErrorStateInternal(string name, string group)
+        {
+            var trigger = await _triggerRepository.Get(PersistentTriggerBase.GetId(InstanceName, group, name));
+            switch (trigger.State)
+            {
+                case PersistentTriggerState.Error:
+                    trigger.State=PersistentTriggerState.Waiting;
+                    await _triggerRepository.Update(trigger);
+                    _logger.Info($"Trigger {name} reset from ERROR state to: {PersistentTriggerState.Waiting}");
+                    break;
+            }
+        }
+
         public async Task PauseTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = new CancellationToken())
         {
             try

--- a/src/Quartz.Spi.CosmosDbJobStore/CosmosDbJobStore.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/CosmosDbJobStore.cs
@@ -812,7 +812,11 @@ namespace Quartz.Spi.CosmosDbJobStore
             switch (trigger.State)
             {
                 case PersistentTriggerState.Error:
-                    trigger.State=PersistentTriggerState.Waiting;
+
+                    trigger.State = await _pausedTriggerGroupRepository.Exists(PausedTriggerGroup.GetId(InstanceName, group))
+                            ? PersistentTriggerState.Paused
+                            : PersistentTriggerState.Waiting;
+
                     await _triggerRepository.Update(trigger);
                     _logger.Info($"Trigger {name} reset from ERROR state to: {PersistentTriggerState.Waiting}");
                     break;

--- a/src/Quartz.Spi.CosmosDbJobStore/Entities/PersistentJob.cs
+++ b/src/Quartz.Spi.CosmosDbJobStore/Entities/PersistentJob.cs
@@ -47,15 +47,13 @@ namespace Quartz.Spi.CosmosDbJobStore.Entities
         public IJobDetail GetJobDetail()
         {
             // The missing properties are figured out at runtime from the job type attributes
-            return new JobDetailImpl()
-            {
-                Key = GetJobKey(),
-                Description = Description,
-                JobType = JobType,
-                JobDataMap = JobDataMap,
-                Durable = Durable,
-                RequestsRecovery = RequestsRecovery
-            };
+            return JobBuilder.Create(JobType)
+                .WithIdentity(GetJobKey())
+                .WithDescription(Description)
+                .SetJobData(JobDataMap)
+                .StoreDurably(Durable)
+                .RequestRecovery(RequestsRecovery)
+                .Build();
         }
 
         public JobKey GetJobKey()

--- a/src/Quartz.Spi.CosmosDbJobStore/Quartz.Spi.CosmosDbJobStore.csproj
+++ b/src/Quartz.Spi.CosmosDbJobStore/Quartz.Spi.CosmosDbJobStore.csproj
@@ -18,10 +18,10 @@
 
     <ItemGroup>
       <PackageReference Include="Common.Logging" Version="3.4.1" />
-      <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.17.1" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-      <PackageReference Include="Quartz" Version="3.3.2" />
-      <PackageReference Include="Quartz.Serialization.Json" Version="3.3.2" />
+      <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.32.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      <PackageReference Include="Quartz" Version="3.6.2" />
+      <PackageReference Include="Quartz.Serialization.Json" Version="3.6.2" />
     </ItemGroup>
 
 </Project>

--- a/src/Quartz.Spi.CosmosDbJobStore/Quartz.Spi.CosmosDbJobStore.csproj
+++ b/src/Quartz.Spi.CosmosDbJobStore/Quartz.Spi.CosmosDbJobStore.csproj
@@ -18,7 +18,7 @@
 
     <ItemGroup>
       <PackageReference Include="Common.Logging" Version="3.4.1" />
-      <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.32.1" />
+      <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.17.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Quartz" Version="3.6.2" />
       <PackageReference Include="Quartz.Serialization.Json" Version="3.6.2" />


### PR DESCRIPTION
Since there were some[ important bug fixes](https://github.com/quartznet/quartznet/releases) provided in Quartz

- [X] Updated Quartz packages to ver. 3.6.2
- [X] Implemented ResetTriggerFromErrorState (related to the [PR 1904](https://github.com/quartznet/quartznet/pull/1904))
- [ ] Regrettably, I couldn't devise a test for the new method as the integration test scheduler lacks a straightforward means to generate a trigger with an "Error" state.
- [ ] CosmosDB nuget package was not updated since the latest version (I've tested v3.32.1) works unstable.